### PR TITLE
Feat: 예산 분배 등록 기능 추가 (+추천기능)

### DIFF
--- a/src/main/java/com/mybudget/controller/BudgetController.java
+++ b/src/main/java/com/mybudget/controller/BudgetController.java
@@ -1,0 +1,51 @@
+package com.mybudget.controller;
+
+import com.mybudget.config.JwtProvider;
+import com.mybudget.dto.BudgetSettingRequestDto;
+import com.mybudget.enums.Categories;
+import com.mybudget.service.BudgetSettingService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/budgets")
+@Api(tags = "Budget API", description = "예산과 관련된 API")
+@RestController
+public class BudgetController {
+
+    private final BudgetSettingService budgetSettingService;
+    private final JwtProvider jwtProvider;
+
+    @GetMapping("/categories")
+    @ApiOperation(value = "예산 카테고리 조회", notes = "예산 카테고리 목록 조회")
+    public ResponseEntity<List<Categories>> getCategories(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+
+        List<Categories> result = budgetSettingService.getCategories();
+
+        return ResponseEntity.status(OK).body(result);
+    }
+
+    @PostMapping
+    @ApiOperation(value = "예산 설정", notes = "사용자 본인의 예산을 설정")
+    public ResponseEntity<Void> createBudget(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token,
+            @Valid @RequestBody BudgetSettingRequestDto budgetSettingRequestDto){
+
+        Long userId = jwtProvider.getIdFromToken(token);
+
+        budgetSettingService.createBudget(userId, budgetSettingRequestDto);
+
+        return ResponseEntity.status(CREATED).build();
+    }
+}

--- a/src/main/java/com/mybudget/controller/UserController.java
+++ b/src/main/java/com/mybudget/controller/UserController.java
@@ -10,7 +10,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")

--- a/src/main/java/com/mybudget/controller/UserController.java
+++ b/src/main/java/com/mybudget/controller/UserController.java
@@ -10,8 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")

--- a/src/main/java/com/mybudget/domain/Budget.java
+++ b/src/main/java/com/mybudget/domain/Budget.java
@@ -1,0 +1,37 @@
+package com.mybudget.domain;
+
+import com.mybudget.dto.BudgetDto;
+import com.mybudget.enums.Categories;
+import lombok.*;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Budget {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private Categories category;
+
+    @Setter
+    private BigDecimal amount;
+
+    public static Budget from(User user, BudgetDto budgetDto) {
+        return Budget.builder()
+                .user(user)
+                .category(budgetDto.getCategory())
+                .amount(budgetDto.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/mybudget/domain/CategoryRatio.java
+++ b/src/main/java/com/mybudget/domain/CategoryRatio.java
@@ -1,0 +1,27 @@
+package com.mybudget.domain;
+
+import com.mybudget.enums.Categories;
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class CategoryRatio extends BaseEntity {
+
+    @Id
+    @Enumerated(EnumType.STRING)
+    private Categories category;
+
+    @Setter
+    private Double ratio;
+
+    @Setter
+    private Integer count;
+}

--- a/src/main/java/com/mybudget/dto/BudgetDto.java
+++ b/src/main/java/com/mybudget/dto/BudgetDto.java
@@ -1,0 +1,24 @@
+package com.mybudget.dto;
+
+import com.mybudget.domain.Budget;
+import com.mybudget.enums.Categories;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BudgetDto {
+    private Categories category;
+    private BigDecimal amount;
+
+    public static BudgetDto from(Budget budget) {
+        return BudgetDto.builder()
+                .category(budget.getCategory())
+                .amount(budget.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/com/mybudget/dto/BudgetSettingRequestDto.java
+++ b/src/main/java/com/mybudget/dto/BudgetSettingRequestDto.java
@@ -1,0 +1,15 @@
+package com.mybudget.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BudgetSettingRequestDto {
+    private BigDecimal totalAmount;
+    List<BudgetDto> budgets;
+}

--- a/src/main/java/com/mybudget/enums/Categories.java
+++ b/src/main/java/com/mybudget/enums/Categories.java
@@ -1,0 +1,10 @@
+package com.mybudget.enums;
+
+public enum Categories {
+    FOOD,
+    TRANSPORTATION,
+    HOUSING,
+    ENTERTAINMENT,
+    EDUCATION,
+    OTHER
+}

--- a/src/main/java/com/mybudget/exception/ErrorCode.java
+++ b/src/main/java/com/mybudget/exception/ErrorCode.java
@@ -17,7 +17,10 @@ public enum ErrorCode {
     USER_INFO_NOT_FOUND(NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
     EXISTING_USER(BAD_REQUEST, "이미 가입한 사용자 입니다."),
     INVALID_OTP(BAD_REQUEST, "유효하지 않은 인증번호 입니다."),
-    INVALID_PASSWORD(BAD_REQUEST,"비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    //budget
+    BUDGET_AMOUNT_NOT_MATCH(BAD_REQUEST, "예산의 총액과 각 예산의 총액이 일치하지 않습니다."),
+    BUDGET_HASNT_BEEN_SET(BAD_REQUEST,"예산이 설정 되지 않은 사용자 입니다." );
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/mybudget/repository/BudgetRepository.java
+++ b/src/main/java/com/mybudget/repository/BudgetRepository.java
@@ -1,0 +1,15 @@
+package com.mybudget.repository;
+
+import com.mybudget.domain.Budget;
+import com.mybudget.domain.User;
+import com.mybudget.enums.Categories;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BudgetRepository extends JpaRepository<Budget, Long> {
+    List<Budget> findByUser(User user);
+
+    Optional<Budget> findByUserAndCategory(User user, Categories category);
+}

--- a/src/main/java/com/mybudget/repository/CategoryRatioRepository.java
+++ b/src/main/java/com/mybudget/repository/CategoryRatioRepository.java
@@ -1,0 +1,12 @@
+package com.mybudget.repository;
+
+import com.mybudget.domain.CategoryRatio;
+import com.mybudget.enums.Categories;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRatioRepository extends JpaRepository<CategoryRatio, Categories> {
+
+    Optional<CategoryRatio> findByCategory(Categories category);
+}

--- a/src/main/java/com/mybudget/service/BudgetSettingService.java
+++ b/src/main/java/com/mybudget/service/BudgetSettingService.java
@@ -1,0 +1,288 @@
+package com.mybudget.service;
+
+import com.mybudget.domain.Budget;
+import com.mybudget.domain.CategoryRatio;
+import com.mybudget.domain.User;
+import com.mybudget.dto.BudgetDto;
+import com.mybudget.dto.BudgetSettingRequestDto;
+import com.mybudget.enums.Categories;
+import com.mybudget.exception.CustomException;
+import com.mybudget.repository.BudgetRepository;
+import com.mybudget.repository.CategoryRatioRepository;
+import com.mybudget.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.mybudget.exception.ErrorCode.USER_INFO_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class BudgetSettingService {
+    private final UserRepository userRepository;
+    private final BudgetRepository budgetRepository;
+    private final CategoryRatioRepository categoryRatioRepository;
+
+    /**
+     * 모든 카테고리 반환
+     */
+    public List<Categories> getCategories() {
+        return Arrays.asList(Categories.values());
+    }
+
+    /**
+     * 사용자의 예산을 설정하거나 업데이트
+     *
+     * @param userId                  사용자 ID
+     * @param budgetSettingRequestDto 예산 설정 요청 DTO
+     * @throws CustomException 유저 정보가 없을 때 발생하는 예외
+     */
+    @Transactional
+    public void createBudget(Long userId, BudgetSettingRequestDto budgetSettingRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_INFO_NOT_FOUND));
+
+        List<BudgetDto> budgetDtos = budgetSettingRequestDto.getBudgets();
+        BigDecimal totalAmount = budgetSettingRequestDto.getTotalAmount();
+
+        /*
+         만약 예산계획이 없이 총 금액만 입력했다면, 예산 계획 추천하여 저장
+         예산계획 추천은 여태 다른 사용자들이 예산을 설정한 퍼센테이지에 따라 추천해 저장.
+         */
+        if (budgetDtos.isEmpty()) {
+            recommendBudgetPlan(user, totalAmount);
+        } else {
+            processBudgetUpdates(user, budgetDtos, totalAmount);
+        }
+    }
+
+    /**
+     * 예산 업데이트
+     *
+     * @param user        사용자 정보
+     * @param budgetDtos  예산 DTO 리스트
+     * @param totalAmount 총 금액
+     */
+    private void processBudgetUpdates(User user,
+                                      List<BudgetDto> budgetDtos,
+                                      BigDecimal totalAmount) {
+
+        List<Budget> existingBudgets = budgetRepository.findByUser(user);
+        Map<Categories, Budget> existingBudgetsMap = mapExistingBudgets(existingBudgets);
+
+        updateOrCreateBudgets(budgetDtos, totalAmount, user, existingBudgetsMap);
+    }
+
+    /**
+     * 기존 예산들을 카테고리를 기준으로 매핑하여 Map으로 반환
+     *
+     * @param existingBudgets 기존 예산 리스트
+     * @return 카테고리를 기준으로 한 예산 Map
+     */
+    private Map<Categories, Budget> mapExistingBudgets(List<Budget> existingBudgets) {
+        return existingBudgets.stream()
+                .collect(Collectors.toMap(Budget::getCategory, budget -> budget));
+    }
+
+    /**
+     * 예산을 업데이트하거나 새로 생성
+     *
+     * @param budgetDtos         예산 DTO 리스트
+     * @param totalAmount        총 금액
+     * @param user               사용자 정보
+     * @param existingBudgetsMap 기존 예산 Map
+     */
+    private void updateOrCreateBudgets(List<BudgetDto> budgetDtos,
+                                       BigDecimal totalAmount,
+                                       User user,
+                                       Map<Categories, Budget> existingBudgetsMap) {
+
+        budgetDtos.forEach(budgetDto -> {
+            Budget existingBudget = existingBudgetsMap.get(budgetDto.getCategory());
+
+            if (existingBudget != null) {
+                updateExistingBudget(existingBudget, budgetDto);
+            } else {
+                budgetRepository.save(Budget.from(user, budgetDto));
+            }
+        });
+
+        updateCategoryRatios(budgetDtos, totalAmount);
+    }
+
+    /**
+     * 기존 예산을 업데이트
+     *
+     * @param existingBudget 기존 예산
+     * @param budgetDto      예산 DTO
+     */
+    private void updateExistingBudget(Budget existingBudget, BudgetDto budgetDto) {
+        existingBudget.setAmount(budgetDto.getAmount());
+        budgetRepository.save(existingBudget);
+    }
+
+    /**
+     * 카테고리 비율을 업데이트하거나 새로운 카테고리 비율 삽입
+     *
+     * @param budgetDtos  예산 DTO 리스트
+     * @param totalAmount 총 금액
+     */
+    private void updateCategoryRatios(List<BudgetDto> budgetDtos, BigDecimal totalAmount) {
+        budgetDtos.forEach(budget -> {
+            BigDecimal percentage = calculatePercentage(budget.getAmount(), totalAmount);
+            updateOrInsertCategoryRatio(budget, percentage);
+        });
+    }
+
+    /**
+     * 금액과 총 금액을 기준으로 백분율 계산
+     *
+     * @param amount      금액
+     * @param totalAmount 총 금액
+     * @return 백분율 계산 결과
+     */
+    private BigDecimal calculatePercentage(BigDecimal amount, BigDecimal totalAmount) {
+        return amount.divide(totalAmount, 2, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"));
+    }
+
+    /**
+     * 카테고리 비율을 업데이트하거나 새로운 카테고리 비율 삽입
+     *
+     * @param budget     예산 DTO
+     * @param percentage 백분율
+     */
+    private void updateOrInsertCategoryRatio(BudgetDto budget, BigDecimal percentage) {
+        Optional<CategoryRatio> categoryRatio =
+                categoryRatioRepository.findByCategory(budget.getCategory());
+
+        if (categoryRatio.isPresent()) {
+            updateCategoryRatio(categoryRatio.get(), percentage);
+        } else {
+            insertCategoryRatio(budget.getCategory(), percentage);
+        }
+    }
+
+    /**
+     * 기존 카테고리 비율 업데이트
+     *
+     * @param existingCategoryRatio 기존 카테고리 비율
+     * @param percentage            백분율
+     */
+    private void updateCategoryRatio(CategoryRatio existingCategoryRatio,
+                                     BigDecimal percentage) {
+
+        Double averagePercentage = existingCategoryRatio.getRatio();
+        Integer count = existingCategoryRatio.getCount();
+
+        Double updatedPercentage =
+                (averagePercentage * count + percentage.doubleValue()) / (count + 1);
+        existingCategoryRatio.setRatio(updatedPercentage);
+        existingCategoryRatio.setCount(count + 1);
+
+        categoryRatioRepository.save(existingCategoryRatio);
+    }
+
+    /**
+     * 카테고리 비율을 새로 삽입
+     *
+     * @param category   카테고리
+     * @param percentage 백분율
+     */
+    private void insertCategoryRatio(Categories category, BigDecimal percentage) {
+        CategoryRatio newCategoryRatio = CategoryRatio.builder()
+                .category(category)
+                .ratio(percentage.doubleValue())
+                .count(1)
+                .build();
+
+        categoryRatioRepository.save(newCategoryRatio);
+    }
+
+    /**
+     * 추천된 예산 계획 생성
+     *
+     * @param user        사용자 정보
+     * @param totalAmount 총 예산 금액
+     */
+    private void recommendBudgetPlan(User user, BigDecimal totalAmount) {
+        // 모든 카테고리를 불러옴.
+        List<Categories> categories = getCategories();
+
+        // 남은 금액을 추적
+        BigDecimal remainingAmount = totalAmount;
+
+        // 각 카테고리별로 예산을 설정
+        for (Categories category : categories) {
+
+            // 카테고리별 비율을 확인
+            Optional<CategoryRatio> categoryRatio =
+                    categoryRatioRepository.findByCategory(category);
+
+            if (categoryRatio.isPresent()) {
+                // 카테고리별로 할당될 금액 계산
+                Double ratio = categoryRatio.get().getRatio();
+                BigDecimal allocatedAmount = totalAmount.multiply(BigDecimal.valueOf(ratio / 100)).setScale(2, RoundingMode.HALF_UP);
+                remainingAmount = remainingAmount.subtract(allocatedAmount);
+
+                // BudgetDto를 생성하여 각 카테고리별로 예산 설정
+                BudgetDto budgetDto = new BudgetDto();
+                budgetDto.setCategory(category);
+                budgetDto.setAmount(allocatedAmount);
+
+                processBudget(user, budgetDto);
+            }
+        }
+
+        // 남은 금액을 카테고리 간에 고르게 분배]
+        if (remainingAmount.compareTo(BigDecimal.ZERO) > 0) {
+            List<BudgetDto> existingBudgets =
+                    budgetRepository.findByUser(user).stream()
+                            .map(BudgetDto::from)
+                            .collect(Collectors.toList());
+
+            // 존재하는 카테고리의 수 확인
+            int numberOfCategories = existingBudgets.size();
+            // 남은 금액을 카테고리 수로 나눠서 고르게 분배
+            if (numberOfCategories > 0) {
+                BigDecimal equalShare =
+                        remainingAmount.divide(
+                                BigDecimal.valueOf(numberOfCategories),
+                                2,
+                                RoundingMode.HALF_UP
+                        );
+
+                existingBudgets.forEach(budget -> {
+                    // 각 카테고리에 고르게 분배된 금액을 추가하여 예산 설정
+                    budget.setAmount(budget.getAmount().add(equalShare));
+                    processBudget(user, budget);
+                });
+            }
+        }
+    }
+
+    /**
+     * 사용자의 예산 처리
+     *
+     * @param user      사용자 정보
+     * @param budgetDto 예산 DTO
+     */
+    private void processBudget(User user, BudgetDto budgetDto) {
+        // 사용자와 카테고리에 따른 예산 가져오거나 새로 생성
+        Budget existingBudget =
+                budgetRepository.findByUserAndCategory(user, budgetDto.getCategory())
+                        .orElse(Budget.from(user, budgetDto));
+
+        // 해당 예산에 새로운 금액 설정
+        existingBudget.setAmount(budgetDto.getAmount());
+        budgetRepository.save(existingBudget);
+    }
+}

--- a/src/test/java/com/mybudget/service/BudgetSettingServiceTest.java
+++ b/src/test/java/com/mybudget/service/BudgetSettingServiceTest.java
@@ -1,0 +1,182 @@
+package com.mybudget.service;
+
+import com.mybudget.config.UserRole;
+import com.mybudget.domain.Budget;
+import com.mybudget.domain.CategoryRatio;
+import com.mybudget.domain.User;
+import com.mybudget.dto.BudgetDto;
+import com.mybudget.dto.BudgetSettingRequestDto;
+import com.mybudget.enums.UserStatus;
+import com.mybudget.repository.BudgetRepository;
+import com.mybudget.repository.CategoryRatioRepository;
+import com.mybudget.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.mybudget.enums.Categories.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("예산 설정 테스트")
+class BudgetSettingServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BudgetRepository budgetRepository;
+
+    @Mock
+    private CategoryRatioRepository categoryRatioRepository;
+
+    private BudgetSettingService budgetSettingService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        budgetSettingService = new BudgetSettingService(
+                userRepository, budgetRepository, categoryRatioRepository
+        );
+    }
+
+    static List<BudgetDto> budgetDtos = Arrays.asList(
+            BudgetDto.builder()
+                    .category(FOOD)
+                    .amount(BigDecimal.valueOf(100000))
+                    .build(),
+            BudgetDto.builder()
+                    .category(OTHER)
+                    .amount(BigDecimal.valueOf(200000))
+                    .build(),
+            BudgetDto.builder()
+                    .category(HOUSING)
+                    .amount(BigDecimal.valueOf(300000))
+                    .build(),
+            BudgetDto.builder()
+                    .category(TRANSPORTATION)
+                    .amount(BigDecimal.valueOf(400000))
+                    .build()
+    );
+    static BudgetSettingRequestDto budgetSettingRequestDto =
+            BudgetSettingRequestDto.builder()
+                    .totalAmount(BigDecimal.valueOf(1000000))
+                    .budgets(budgetDtos)
+                    .build();
+
+    static BudgetSettingRequestDto budgetSettingRequestDtoWOList =
+            BudgetSettingRequestDto.builder()
+                    .totalAmount(BigDecimal.valueOf(1000000))
+                    .budgets(new ArrayList<>())
+                    .build();
+
+    static User user = User.builder()
+            .id(1L)
+            .email("email@test.com")
+            .phoneNumber("112333333")
+            .password("aaaaa")
+            .userStatus(UserStatus.ACTIVE)
+            .userRole(UserRole.ROLE_USER)
+            .build();
+
+    @Test
+    @DisplayName("성공 - 일반")
+    public void createBudget_success_normal() {
+        // given
+        Long userId = 1L;
+
+        when(userRepository.findById(userId))
+                .thenReturn(Optional.of(user));
+        when(budgetRepository.findByUser(user))
+                .thenReturn(new ArrayList<>());
+
+        // when
+        budgetSettingService.createBudget(userId, budgetSettingRequestDto);
+
+        // then
+        assertEquals(4, budgetDtos.size());
+        verify(budgetRepository, Mockito.times(4))
+                .save(Mockito.any(Budget.class));
+    }
+
+    @Test
+    @DisplayName("성공 - 예산 계획 추천")
+    public void createBudget_success_w_no_list() {
+        // given
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(budgetRepository.findByUser(user)).thenReturn(new ArrayList<>());
+        when(categoryRatioRepository.findAll())
+                .thenReturn(Arrays.asList(
+                        CategoryRatio.builder()
+                                .category(FOOD)
+                                .ratio(10.0)
+                                .build(),
+                        CategoryRatio.builder()
+                                .category(OTHER)
+                                .ratio(20.0)
+                                .build(),
+                        CategoryRatio.builder()
+                                .category(HOUSING)
+                                .ratio(20.0)
+                                .build(),
+                        CategoryRatio.builder()
+                                .category(TRANSPORTATION)
+                                .ratio(50.0)
+                                .build()
+                ));
+        when(categoryRatioRepository.findByCategory(FOOD))
+                .thenReturn(Optional.of(
+                        CategoryRatio.builder()
+                                .category(FOOD)
+                                .ratio(10.0)
+                                .build()
+                ));
+        when(categoryRatioRepository.findByCategory(OTHER))
+                .thenReturn(Optional.of(
+                        CategoryRatio.builder()
+                                .category(OTHER)
+                                .ratio(20.0)
+                                .build()
+                ));
+        when(categoryRatioRepository.findByCategory(HOUSING))
+                .thenReturn(Optional.of(
+                        CategoryRatio.builder()
+                                .category(HOUSING)
+                                .ratio(20.0)
+                                .build()
+                ));
+        when(categoryRatioRepository.findByCategory(TRANSPORTATION))
+                .thenReturn(Optional.of(
+                        CategoryRatio.builder()
+                                .category(TRANSPORTATION)
+                                .ratio(50.0)
+                                .build()
+                ));
+        when(budgetRepository.findByUserAndCategory(user, FOOD))
+                .thenReturn(Optional.empty());
+        when(budgetRepository.findByUserAndCategory(user, OTHER))
+                .thenReturn(Optional.empty());
+        when(budgetRepository.findByUserAndCategory(user, HOUSING))
+                .thenReturn(Optional.empty());
+        when(budgetRepository.findByUserAndCategory(user, TRANSPORTATION))
+                .thenReturn(Optional.empty());
+
+        // when
+        budgetSettingService.createBudget(userId, budgetSettingRequestDtoWOList);
+
+        // then
+        assertEquals(4, budgetDtos.size());
+        verify(budgetRepository, Mockito.times(4))
+                .save(Mockito.any(Budget.class));    }
+}


### PR DESCRIPTION
### 변경사항
-  예산 등록 기능 추가 (예산분배 추천기능 추가) 

##### TO-BE
- 예산등록 프로세스
    1. 예산 목록과 총예산을 받음
    2. 예산 목록이 비어있을 경우 추천 예산을 토대로 예산분배
        2.1 예산추천은 기존 회원들의 예산 추이 (퍼센테이지) 에 따라 분배
        2.2 같은 카테고리에 기존 예산 정보가 있는 상태일 경우 업데이트
    3. 예산목록이 비어있지 않을 경우 입력된 대로 예산 분배 등록

##### 테스트
- [x] 테스트 코드
- [x] API 테스트