### PR TITLE
Feat: 본인이 등록한 지출내역 수정하는 기능추가

### DIFF
--- a/src/main/java/com/mybudget/controller/ExpenseController.java
+++ b/src/main/java/com/mybudget/controller/ExpenseController.java
@@ -3,6 +3,7 @@ package com.mybudget.controller;
 import com.mybudget.config.JwtProvider;
 import com.mybudget.dto.ExpenseCreationRequestDto;
 import com.mybudget.dto.ExpenseListResponseDto;
+import com.mybudget.dto.ExpenseModificationRequestDto;
 import com.mybudget.enums.Categories;
 import com.mybudget.service.ExpenseService;
 import io.swagger.annotations.Api;
@@ -61,5 +62,19 @@ public class ExpenseController {
                 );
 
         return ResponseEntity.status(HttpStatus.OK).body(expenses);
+    }
+
+    @PatchMapping("/{expenseId}")
+    @ApiOperation(value = "지출 수정", notes = "사용자 본인의 지출을 수정")
+    public ResponseEntity<Void> updateExpense(
+            @RequestHeader(AUTHORIZATION) String token,
+            @PathVariable Long expenseId,
+            @Valid @RequestBody ExpenseModificationRequestDto expenseModificationRequestDto) {
+
+        Long userId = jwtProvider.getIdFromToken(token);
+
+        expenseService.updateExpense(userId, expenseId, expenseModificationRequestDto);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/mybudget/domain/Expense.java
+++ b/src/main/java/com/mybudget/domain/Expense.java
@@ -2,10 +2,7 @@ package com.mybudget.domain;
 
 import com.mybudget.dto.ExpenseCreationRequestDto;
 import com.mybudget.enums.Categories;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
@@ -24,14 +21,17 @@ public class Expense extends BaseEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    @Setter
     private String description;
 
     private Categories category;
 
+    @Setter
     private BigDecimal amount;
 
     private Date expenseDate;
 
+    @Setter
     private Boolean excluding;
 
     public static Expense from(User user,

--- a/src/main/java/com/mybudget/dto/ExpenseModificationRequestDto.java
+++ b/src/main/java/com/mybudget/dto/ExpenseModificationRequestDto.java
@@ -1,0 +1,23 @@
+package com.mybudget.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ExpenseModificationRequestDto {
+
+    @Positive(message = "금액은 0보다 커야합니다")
+    private BigDecimal amount;
+
+    private String description;
+
+    private Boolean excluding;
+}

--- a/src/main/java/com/mybudget/exception/ErrorCode.java
+++ b/src/main/java/com/mybudget/exception/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode {
     BUDGET_ALREADY_EXISTS(BAD_REQUEST, "해당 날짜에 이미 등록된 예산이 있습니다. " +
             "기존 예산을 삭제하거나 적용날짜를 변경한 후 다시 시도 해주세요."),
     BUDGET_AMOUNT_TOO_SMALL(BAD_REQUEST, "최소 예산은 1000원 입니다."),
-    INVALID_BUDGET_DATE(BAD_REQUEST,"시작일은 종료일보다 빠를 수 없습니다.");
+    INVALID_BUDGET_DATE(BAD_REQUEST,"시작일은 종료일보다 빠를 수 없습니다."),
+    EXPENSE_NOT_FOUND(BAD_REQUEST,"지출 정보를 찾을 수 없습니다."),
+    NOT_MY_EXPENSE(BAD_REQUEST, "본인의 지출만 수정/삭제할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/mybudget/service/ExpenseModificationTest.java
+++ b/src/test/java/com/mybudget/service/ExpenseModificationTest.java
@@ -1,0 +1,118 @@
+package com.mybudget.service;
+
+import com.mybudget.config.UserRole;
+import com.mybudget.domain.Expense;
+import com.mybudget.domain.User;
+import com.mybudget.dto.ExpenseModificationRequestDto;
+import com.mybudget.enums.Categories;
+import com.mybudget.enums.UserStatus;
+import com.mybudget.exception.CustomException;
+import com.mybudget.repository.ExpenseRepository;
+import com.mybudget.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.Optional;
+
+import static com.mybudget.exception.ErrorCode.NOT_MY_EXPENSE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@DisplayName("지출 내역 수정")
+class ExpenseModificationTest {
+
+    @Mock
+    private ExpenseRepository expenseRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private ExpenseService expenseService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        expenseService = new ExpenseService(expenseRepository, userRepository);
+    }
+
+    public static User user = User.builder()
+            .id(1L)
+            .email("email@test.com")
+            .phoneNumber("112333333")
+            .password("aaaaa")
+            .userStatus(UserStatus.ACTIVE)
+            .userRole(UserRole.ROLE_USER)
+            .build();
+
+    @Test
+    @DisplayName("성공")
+    void testModifyExpense_success() {
+        //given
+        ExpenseModificationRequestDto expenseModificationRequestDto =
+                ExpenseModificationRequestDto.builder()
+                        .amount(BigDecimal.valueOf(10000))
+                        .description("수정된 내용")
+                        .excluding(true)
+                        .build();
+
+        Expense expense = Expense.builder()
+                .id(1L)
+                .user(user)
+                .description("수정 전 내용")
+                .category(Categories.FOOD)
+                .amount(BigDecimal.valueOf(20000))
+                .expenseDate(Date.valueOf("2024-01-01"))
+                .excluding(false)
+                .build();
+
+        when(expenseRepository.findById(1L)).thenReturn(Optional.of(expense));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+        //when
+        expenseService.updateExpense(
+                user.getId(), expense.getId(), expenseModificationRequestDto
+        );
+
+        //then
+        assertThat(expense.getAmount()).isEqualTo(BigDecimal.valueOf(10000));
+        assertThat(expense.getDescription()).isEqualTo("수정된 내용");
+        assertThat(expense.getExcluding()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("실패 - 본인 지출 아님")
+    void testModifyExpense_fail_not_my_expense() {
+        //given
+        ExpenseModificationRequestDto expenseModificationRequestDto =
+                ExpenseModificationRequestDto.builder()
+                        .amount(BigDecimal.valueOf(10000))
+                        .description("수정된 내용")
+                        .excluding(true)
+                        .build();
+
+        Expense expense = Expense.builder()
+                .id(1L)
+                .user(User.builder().id(2L).build())
+                .description("수정 전 내용")
+                .category(Categories.FOOD)
+                .amount(BigDecimal.valueOf(20000))
+                .expenseDate(Date.valueOf("2024-01-01"))
+                .excluding(false)
+                .build();
+
+        when(expenseRepository.findById(1L)).thenReturn(Optional.of(expense));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+        //when&then
+        assertThatThrownBy(() -> expenseService.updateExpense(
+                user.getId(), expense.getId(), expenseModificationRequestDto
+        )).isInstanceOf(CustomException.class)
+                .hasMessage(NOT_MY_EXPENSE.getMessage());
+    }
+}


### PR DESCRIPTION
### 변경사항
- 본인이 등록한 지출내역 수정하는 기능추가
##### TO-BE
- 수정가능한 필드는 총 3개 이며 (메모,금액,합계제외여부)
- 세 필드 모두 하나의 api로 수정하고 `null`로 들어오면 미 수정, 값이 들어오면 수정 진행
##### 테스트
- [x] 테스트 코드
- [x] API 테스트