### PR TITLE
Feat: 지출 등록 시 해당 날짜의 카테고리 예산금액을 함께 저장하도록 수정 

### DIFF
--- a/src/main/java/com/mybudget/domain/Expense.java
+++ b/src/main/java/com/mybudget/domain/Expense.java
@@ -13,7 +13,7 @@ import java.sql.Date;
 @AllArgsConstructor
 @Builder
 @Entity
-public class Expense extends BaseEntity{
+public class Expense extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -31,11 +31,14 @@ public class Expense extends BaseEntity{
 
     private Date expenseDate;
 
+    private BigDecimal budgetTotalAmount;
+
     @Setter
     private Boolean excluding;
 
     public static Expense from(User user,
-                               ExpenseCreationRequestDto expenseCreationRequestDto) {
+                               ExpenseCreationRequestDto expenseCreationRequestDto,
+                               BigDecimal budgetTotalAmount) {
         return Expense.builder()
                 .user(user)
                 .description(expenseCreationRequestDto.getDescription())
@@ -43,6 +46,7 @@ public class Expense extends BaseEntity{
                 .amount(expenseCreationRequestDto.getAmount())
                 .excluding(expenseCreationRequestDto.getExcluding())
                 .expenseDate(expenseCreationRequestDto.getExpenseDate())
+                .budgetTotalAmount(budgetTotalAmount)
                 .build();
     }
 }

--- a/src/main/java/com/mybudget/repository/BudgetRepository.java
+++ b/src/main/java/com/mybudget/repository/BudgetRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,4 +24,7 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     BigDecimal getAmountOfCategory(@Param("category") Categories category);
 
     Optional<Budget> findByCategory(Categories category);
+
+    @Query("SELECT b FROM Budget b WHERE b.user = :user AND b.startDate <= :date AND b.endDate >= :date")
+    List<Budget> findByUserAndDate(@Param("user") User user, @Param("date") Date date);
 }

--- a/src/test/java/com/mybudget/service/BudgetSettingTest.java
+++ b/src/test/java/com/mybudget/service/BudgetSettingTest.java
@@ -6,11 +6,8 @@ import com.mybudget.domain.User;
 import com.mybudget.dto.BudgetDto;
 import com.mybudget.dto.BudgetSettingRequestDto;
 import com.mybudget.enums.UserStatus;
-import com.mybudget.exception.CustomException;
-import com.mybudget.exception.ErrorCode;
 import com.mybudget.repository.BudgetRepository;
 import com.mybudget.repository.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +17,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.math.BigDecimal;
 import java.sql.Date;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 import static com.mybudget.enums.Categories.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -109,25 +109,5 @@ class BudgetSettingTest {
         assertEquals(4, budgetDtos.size());
         verify(budgetRepository, Mockito.times(4))
                 .save(Mockito.any(Budget.class));
-    }
-
-    @Test
-    @DisplayName("실패 - 겹치는 날짜에 예산계획이 등록되어 있는 경우")
-    public void createBudget_fail_existing_budget() {
-        // given
-        Long userId = 1L;
-
-        when(userRepository.findById(userId))
-                .thenReturn(Optional.of(user));
-        when(budgetRepository.findByUser(user))
-                .thenReturn(Collections.singletonList(budget));
-        when(budgetRepository.findByUserAndCategory(user, FOOD))
-                .thenReturn(Collections.singletonList(budget));
-
-
-        // when&then
-        Assertions.assertThatThrownBy(() -> budgetService.createBudget(userId, budgetSettingRequestDto))
-                .isInstanceOf(CustomException.class)
-                .hasMessage(ErrorCode.BUDGET_ALREADY_EXISTS.getMessage());
     }
 }

--- a/src/test/java/com/mybudget/service/ExpenseCreationTest.java
+++ b/src/test/java/com/mybudget/service/ExpenseCreationTest.java
@@ -4,6 +4,7 @@ import com.mybudget.config.UserRole;
 import com.mybudget.domain.User;
 import com.mybudget.dto.ExpenseCreationRequestDto;
 import com.mybudget.enums.UserStatus;
+import com.mybudget.repository.BudgetRepository;
 import com.mybudget.repository.ExpenseRepository;
 import com.mybudget.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,12 +28,17 @@ class ExpenseCreationTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private BudgetRepository budgetRepository;
+
     private ExpenseService expenseService;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        expenseService = new ExpenseService(expenseRepository, userRepository);
+        expenseService = new ExpenseService(
+                expenseRepository, budgetRepository, userRepository
+        );
     }
 
     static ExpenseCreationRequestDto expenseCreationRequestDto =

--- a/src/test/java/com/mybudget/service/ExpenseDeletionTest.java
+++ b/src/test/java/com/mybudget/service/ExpenseDeletionTest.java
@@ -6,6 +6,7 @@ import com.mybudget.domain.User;
 import com.mybudget.enums.Categories;
 import com.mybudget.enums.UserStatus;
 import com.mybudget.exception.CustomException;
+import com.mybudget.repository.BudgetRepository;
 import com.mybudget.repository.ExpenseRepository;
 import com.mybudget.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,13 +32,19 @@ class ExpenseDeletionTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private BudgetRepository budgetRepository;
+
     private ExpenseService expenseService;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        expenseService = new ExpenseService(expenseRepository, userRepository);
+        expenseService = new ExpenseService(
+                expenseRepository, budgetRepository, userRepository
+        );
     }
+
 
     static User user = User.builder()
             .id(1L)

--- a/src/test/java/com/mybudget/service/ExpenseInquiryTest.java
+++ b/src/test/java/com/mybudget/service/ExpenseInquiryTest.java
@@ -5,6 +5,7 @@ import com.mybudget.domain.User;
 import com.mybudget.dto.AmountsOfCategoryDto;
 import com.mybudget.dto.ExpenseListResponseDto;
 import com.mybudget.enums.Categories;
+import com.mybudget.repository.BudgetRepository;
 import com.mybudget.repository.ExpenseRepository;
 import com.mybudget.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,12 +33,17 @@ class ExpenseInquiryTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private BudgetRepository budgetRepository;
+
     private ExpenseService expenseService;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        expenseService = new ExpenseService(expenseRepository, userRepository);
+        expenseService = new ExpenseService(
+                expenseRepository, budgetRepository, userRepository
+        );
     }
 
     @Test

--- a/src/test/java/com/mybudget/service/ExpenseModificationTest.java
+++ b/src/test/java/com/mybudget/service/ExpenseModificationTest.java
@@ -7,6 +7,7 @@ import com.mybudget.dto.ExpenseModificationRequestDto;
 import com.mybudget.enums.Categories;
 import com.mybudget.enums.UserStatus;
 import com.mybudget.exception.CustomException;
+import com.mybudget.repository.BudgetRepository;
 import com.mybudget.repository.ExpenseRepository;
 import com.mybudget.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,12 +34,17 @@ class ExpenseModificationTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private BudgetRepository budgetRepository;
+
     private ExpenseService expenseService;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        expenseService = new ExpenseService(expenseRepository, userRepository);
+        expenseService = new ExpenseService(
+                expenseRepository, budgetRepository, userRepository
+        );
     }
 
     public static User user = User.builder()


### PR DESCRIPTION
### 변경사항
- 지출 등록 시 해당 날짜의 카테고리 예산금액을 함께 저장하도록 수정 
##### TO-BE
- 추후 통계에 사용하기 위한 필드
##### 테스트
- [x] 테스트 코드
- [x] API 테스트