### PR TITLE
Fix: 사용자 지출내역 생성도중 0으로 나누어 발생하는 예외 수정

### DIFF
--- a/src/main/java/com/mybudget/service/ExpenseService.java
+++ b/src/main/java/com/mybudget/service/ExpenseService.java
@@ -58,7 +58,7 @@ public class ExpenseService {
         BigDecimal budgetTotalAmount = budgets.stream()
                 .filter(budget -> budget.getCategory().equals(expenseCreationRequestDto.getCategory()))
                 .map(Budget::getAmount)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
+                .reduce(BigDecimal.ONE, BigDecimal::add);
 
         expenseRepository.save(
                 Expense.from(user, expenseCreationRequestDto, budgetTotalAmount)


### PR DESCRIPTION
### 변경사항
- 만약 지정된 예산이 없는 카테고리의 경우 기본값인 0이 들어가는 경우
  예외 발생.  연산 시 예외발생하여 해당부분 1을 기본값으로 지정하여 해결

##### 테스트
- [x] 테스트 코드
- [x] API 테스트